### PR TITLE
Updated cli.js to default n to NaN

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -34,7 +34,7 @@ const cli = meow(
       },
       n: {
         type: 'number',
-        default: 1,
+        default: NaN,
       },
     },
   },


### PR DESCRIPTION
Current version of snake-names is broken. This update should fix the issue where a default number is given for n when having n specified throws an error.